### PR TITLE
check if local optimization was successful before using it over global

### DIFF
--- a/src/tankoh2/design/winding/optimize.py
+++ b/src/tankoh2/design/winding/optimize.py
@@ -127,7 +127,7 @@ def minimizeUtilization(bounds, targetFunction, optArgs, localOptimization = Fal
         if localOptimization is False:
             popt = popt_glob
     if localOptimization == 'both':
-        popt = popt_loc if popt_loc.fun < popt_glob.fun else popt_glob
+        popt = popt_loc if popt_loc.fun < popt_glob.fun and popt_loc.success else popt_glob
         if not popt.success:
             popt = popt_loc if popt_loc.fun > popt_glob.fun else popt_glob
     if not popt.success:


### PR DESCRIPTION
doesn't solve the problem of the local optimizer, but should prevent errors ending the program (which happens in the condition that the local optimizer fails but still gives a better result than global)